### PR TITLE
Populate hidden addressType field when shopper adds location manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Error message if user has blocked browser location but tries to use `Find My Location` button
+
+### Fixed
+
+- `addressType` field will be automatically set if user inputs address manually
+
 ## [0.1.2] - 2020-09-22
 
 ### Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -3,6 +3,7 @@
   "store/shopper-location.change-location.addressNotApplicable": "store/shopper-location.change-location.addressNotApplicable",
   "store/shopper-location.change-location.trigger-geolocation": "store/shopper-location.change-location.trigger-geolocation",
   "store/shopper-location.change-location.error-country": "store/shopper-location.change-location.error-country",
+  "store/shopper-location.change-location.error-permission": "store/shopper-location.change-location.error-permission",
   "store/shopper-location.change-location.submit": "store/shopper-location.change-location.submit",
 
   "store/shopper-location.countries.ABW": "store/shopper-location.countries.ABW",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,6 +3,7 @@
   "store/shopper-location.change-location.addressNotApplicable": "Not applicable",
   "store/shopper-location.change-location.trigger-geolocation": "Find my location",
   "store/shopper-location.change-location.error-country": "Sorry, shipping is not available for your location.",
+  "store/shopper-location.change-location.error-permission": "Failed to find your location. Please check that you have granted permission for this site to use your location.",
   "store/shopper-location.change-location.submit": "SAVE",
 
   "store/shopper-location.countries.ABW": "Aruba",

--- a/react/components/ChangeLocationContainer.tsx
+++ b/react/components/ChangeLocationContainer.tsx
@@ -38,7 +38,7 @@ const ChangeLocation: FunctionComponent<WrappedComponentProps> = ({ intl }) => {
     street: queriedAddress?.street || '',
     postalCode: queriedAddress?.postalCode || '',
     city: queriedAddress?.city || '',
-    addressType: queriedAddress?.addressType || '',
+    addressType: queriedAddress?.addressType || 'residential',
     geoCoordinates: queriedAddress?.geoCoordinates || [],
     state: queriedAddress?.state || '',
     receiverName: queriedAddress?.receiverName || '',

--- a/react/components/LocationContext.tsx
+++ b/react/components/LocationContext.tsx
@@ -22,7 +22,7 @@ const addressWithoutValidation = {
   street: '',
   postalCode: '',
   city: '',
-  addressType: '',
+  addressType: 'residential',
   geoCoordinates: [],
   state: '',
   receiverName: '',

--- a/react/components/LocationForm.tsx
+++ b/react/components/LocationForm.tsx
@@ -101,6 +101,7 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
   const { location } = useLocationState()
   const locationDispatch = useLocationDispatch()
   const [countryError, setCountryError] = useState(false)
+  const [geoError, setGeoError] = useState(false)
   const [locationLoading, setLocationLoading] = useState(false)
   const [geoLoading, setGeoLoading] = useState(false)
   const isMountedRef = useRef(false)
@@ -192,6 +193,7 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
   }
 
   const handleError = () => {
+    setGeoError(true)
     setGeoLoading(false)
     clearTimeout(loadingTimeout)
     return
@@ -302,6 +304,12 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
                 className={`${handles.changeLocationGeoErrorContainer} mt2 red`}
               >
                 <FormattedMessage id="store/shopper-location.change-location.error-country" />
+              </div>
+            ) : geoError ? (
+              <div
+                className={`${handles.changeLocationGeoErrorContainer} mt2 red`}
+              >
+                <FormattedMessage id="store/shopper-location.change-location.error-permission" />
               </div>
             ) : (
               <ButtonWithIcon


### PR DESCRIPTION
Linked here: https://geolocation--sandboxusdev.myvtex.com/

To validate:
1. Clear cookies if you already have a saved location on the above site
2. If you have previously granted permission to use your location, clear that setting
3. Refresh the page
4. Deny the request to use your location
5. Attempt to add your location manually

This PR also adds an error message if the shopper has previously blocked the browser location service and tries to click the Find My Location button.