### PR TITLE
Change priority of city fields in Google response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Change priority of fields from Google response to determine shopper's city
+- Add maxWidth to "Find My Location" error message container on location form
+
 ## [0.1.3] - 2020-09-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "devDependencies": {
     "@vtex/prettier-config": "0.1.3",
     "eslint": "6.8.0",
-    "eslint-config-vtex": "12.2.1",
-    "eslint-config-vtex-react": "6.2.1",
+    "eslint-config-vtex": "^12.7.0",
+    "eslint-config-vtex-react": "^6.7.0",
     "husky": "4.2.0",
     "lint-staged": "10.0.2",
     "prettier": "1.19.1",

--- a/react/ChangeLocation.tsx
+++ b/react/ChangeLocation.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+
 import ChangeLocationContainer from './components/ChangeLocationContainer'
 import {
   LocationContextProvider,

--- a/react/components/ChangeLocationContainer.tsx
+++ b/react/components/ChangeLocationContainer.tsx
@@ -4,6 +4,7 @@ import { injectIntl, WrappedComponentProps } from 'react-intl'
 import { AddressRules } from 'vtex.address-form'
 import { Spinner } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
+
 import address from '../graphql/GetOrderForm.graphql'
 import Logistics from '../graphql/Logistics.graphql'
 import LocationForm from './LocationForm'

--- a/react/components/LocationContext.tsx
+++ b/react/components/LocationContext.tsx
@@ -39,6 +39,7 @@ const initialLocationState = {
 const LocationStateContext = React.createContext<LocationContextProps>(
   initialLocationState
 )
+
 const LocationDispatchContext = React.createContext<Dispatch | undefined>(
   undefined
 )
@@ -53,6 +54,7 @@ function reducer(
         ...state,
         location: action.args.address,
       }
+
     default:
       return state
   }
@@ -62,6 +64,7 @@ const LocationContextProvider: FunctionComponent<LocationContextProps> = ({
   children,
 }) => {
   const [state, dispatch] = useReducer(reducer, initialLocationState)
+
   return (
     <LocationStateContext.Provider value={state}>
       <LocationDispatchContext.Provider value={dispatch}>
@@ -73,11 +76,13 @@ const LocationContextProvider: FunctionComponent<LocationContextProps> = ({
 
 function useLocationState() {
   const context = useContext(LocationStateContext)
+
   if (context === undefined) {
     throw new Error(
       'useLocationState must be used within a LocationStateContextProvider'
     )
   }
+
   return context
 }
 
@@ -89,6 +94,7 @@ function useLocationDispatch() {
       'useLocationDispatch must be used within a LocationDispatchContextProvider'
     )
   }
+
   return context
 }
 

--- a/react/components/LocationForm.tsx
+++ b/react/components/LocationForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react'
 import { useMutation } from 'react-apollo'
 import { WrappedComponentProps, FormattedMessage } from 'react-intl'
@@ -13,6 +14,7 @@ import {
 import { Button, ButtonWithIcon, IconLocation } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 import { useDevice } from 'vtex.device-detector'
+
 import MapContainer from './Map'
 import { useLocationState, useLocationDispatch } from './LocationContext'
 import { getParsedAddress } from '../helpers/getParsedAddress'
@@ -63,23 +65,28 @@ const getGeolocation = async (key: string, address: any) => {
         ?.value || ''}`
     ).trim()
   )
+
   if (!query) return
   let results: any = []
   let geolocation: any = []
+
   try {
     const response = await fetch(
       `https://maps.googleapis.com/maps/api/geocode/json?address=${query}&key=${key}`
     )
+
     results = await response.json()
     if (results.results.length) {
       const {
         results: [result],
       } = results
+
       const {
         geometry: {
           location: { lat, lng },
         },
       } = result
+
       geolocation = [lng, lat]
     }
   } catch (err) {
@@ -112,6 +119,7 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
   useEffect(() => {
     isMountedRef.current = true
     const addressWithValidation = addValidation(currentAddress)
+
     if (isMountedRef.current) {
       locationDispatch({
         type: 'SET_LOCATION',
@@ -120,10 +128,11 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
         },
       })
     }
+
     return () => {
       isMountedRef.current = false
     }
-  }, [])
+  }, [currentAddress, locationDispatch])
 
   const requestGoogleMapsApi = async (params: {
     lat: number
@@ -132,11 +141,14 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
     const { lat, long } = params
     const baseUrl = `https://maps.googleapis.com/maps/api/geocode/json?key=${googleMapsKey}&`
     let suffix = ''
+
     if (lat && long) {
       suffix = `latlng=${lat},${long}`
     }
+
     try {
       const response = await fetch(baseUrl + suffix)
+
       return await response.json()
     } catch (err) {
       return { results: [] }
@@ -150,18 +162,22 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
       lat: latitude,
       long: longitude,
     })
+
     if (!parsedResponse.results.length) {
       setGeoLoading(false)
       clearTimeout(loadingTimeout)
+
       return
     }
 
     // save geolocation to state
     const addressFields = getParsedAddress(parsedResponse.results[0])
+
     if (!shipsTo.includes(addressFields.country)) {
       setCountryError(true)
       setGeoLoading(false)
       clearTimeout(loadingTimeout)
+
       return
     }
 
@@ -174,14 +190,16 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
       postalCode: addressFields.postalCode || '',
       city: addressFields.city || '',
       addressType: addressFields.addressType || '',
-      geoCoordinates: addressFields.geoCoordinates || [],
+      geoCoordinates: addressFields.geoCoordinates ?? [],
       state: addressFields.state || '',
-      receiverName: location.receiverName.value || '',
+      receiverName: location.receiverName.value ?? '',
       reference: '',
       country: addressFields.country || '',
     }
+
     const fieldsWithValidation = addValidation(geolocatedAddress)
     const validatedFields = validateAddress(fieldsWithValidation, rules)
+
     locationDispatch({
       type: 'SET_LOCATION',
       args: {
@@ -196,7 +214,6 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
     setGeoError(true)
     setGeoLoading(false)
     clearTimeout(loadingTimeout)
-    return
   }
 
   const handleGeolocation = () => {
@@ -212,7 +229,8 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
 
   const handleUpdateAddress = () => {
     setLocationLoading(true)
-    let newAddress = removeValidation(location)
+    const newAddress = removeValidation(location)
+
     updateAddress({
       variables: {
         orderFormId,
@@ -234,8 +252,9 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
       .catch(() => null)
       .then(() => {
         const event = new Event('locationUpdated')
+
         window.dispatchEvent(event)
-        dispatch && dispatch({ type: 'CLOSE_MODAL' })
+        dispatch?.({ type: 'CLOSE_MODAL' })
       })
   }
 
@@ -247,8 +266,7 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
 
     geoTimeout = setTimeout(() => {
       getGeolocation(googleMapsKey, validatedAddress).then((res: any) => {
-        console.log(res)
-        if (res && res.length && isMountedRef.current) {
+        if (res?.length && isMountedRef.current) {
           locationDispatch({
             type: 'SET_LOCATION',
             args: {
@@ -281,6 +299,7 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
     ) {
       shipsTo.push(location.country.value as string)
     }
+
     return shipsTo.map((code: string) => ({
       label: intl.formatMessage({
         id: `store/shopper-location.countries.${code}`,
@@ -302,12 +321,14 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
             {countryError ? (
               <div
                 className={`${handles.changeLocationGeoErrorContainer} mt2 red`}
+                style={{ maxWidth: 300 }}
               >
                 <FormattedMessage id="store/shopper-location.change-location.error-country" />
               </div>
             ) : geoError ? (
               <div
                 className={`${handles.changeLocationGeoErrorContainer} mt2 red`}
+                style={{ maxWidth: 300 }}
               >
                 <FormattedMessage id="store/shopper-location.change-location.error-permission" />
               </div>
@@ -338,7 +359,7 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
                 address={location}
                 Input={StyleguideInput}
                 omitAutoCompletedFields={false}
-                omitPostalCodeFields={true}
+                omitPostalCodeFields
                 onChangeAddress={(newAddress: AddressFormFields) =>
                   handleAddressChange(newAddress)
                 }

--- a/react/components/LocationForm.tsx
+++ b/react/components/LocationForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react'
 import { useMutation } from 'react-apollo'
@@ -132,7 +133,7 @@ const LocationForm: FunctionComponent<WrappedComponentProps & AddressProps> = ({
     return () => {
       isMountedRef.current = false
     }
-  }, [currentAddress, locationDispatch])
+  }, [])
 
   const requestGoogleMapsApi = async (params: {
     lat: number

--- a/react/components/Map.tsx
+++ b/react/components/Map.tsx
@@ -1,11 +1,19 @@
-import React, { useEffect, useState, useRef, FunctionComponent } from 'react'
+import React, {
+  useEffect,
+  useState,
+  useMemo,
+  useRef,
+  FunctionComponent,
+  useCallback,
+} from 'react'
 import { components } from 'vtex.address-form'
+
 import markerIconBlue from '../assets/icons/marker.svg'
 
 interface MapContainerProps {
+  intl: any
   googleMapsApiKey: string
   geoCoordinates: any
-  intl: any
 }
 
 interface MapProps {
@@ -16,10 +24,11 @@ interface MapProps {
 const mapStyles = {
   height: '100%',
   width: '100%',
-  position: 'absolute' as 'absolute',
+  position: 'absolute' as const,
   top: 0,
   zIndex: 0,
 }
+
 let map: any = null
 let marker: any = null
 const { GoogleMapsContainer } = components
@@ -28,7 +37,7 @@ const MapContainer: FunctionComponent<MapContainerProps> = ({
   intl,
   googleMapsApiKey,
   geoCoordinates = [],
-}) => {
+}: MapContainerProps) => {
   return (
     <GoogleMapsContainer apiKey={googleMapsApiKey} locale={intl.locale}>
       {({ loading, googleMaps }: { loading: boolean; googleMaps: any }) =>
@@ -42,35 +51,45 @@ const MapContainer: FunctionComponent<MapContainerProps> = ({
 
 const Map: FunctionComponent<MapProps> = ({ googleMaps, geoCoordinates }) => {
   const [last, setLast] = useState('')
-  const getLocation = (geoCoordinates: number[]) => {
-    const [lng, lat] = geoCoordinates
-    const location = new googleMaps.LatLng(lat, lng)
-    return location
-  }
+  const getLocation = useCallback(
+    (coordinates: number[]) => {
+      const [lng, lat] = coordinates
+      const location = new googleMaps.LatLng(lat, lng)
+
+      return location
+    },
+    [googleMaps.LatLng]
+  )
 
   const mapDiv = useRef(null)
-  const mapOptions = {
-    zoom: 12,
-    mapTypeControl: false,
-    zoomControl: true,
-    fullscreenControl: false,
-    streetViewControl: false,
-    color: '#00ff00',
-    clickableIcons: false,
-    zoomControlOptions: {
-      position: googleMaps.ControlPosition.CENTER_RIGHT,
-      style: googleMaps.ZoomControlStyle.SMALL,
-    },
-    styles: [
-      {
-        featureType: 'poi',
-        stylers: [{ visibility: 'off' }],
+  const mapOptions = useMemo(() => {
+    return {
+      zoom: 12,
+      mapTypeControl: false,
+      zoomControl: true,
+      fullscreenControl: false,
+      streetViewControl: false,
+      color: '#00ff00',
+      clickableIcons: false,
+      zoomControlOptions: {
+        position: googleMaps.ControlPosition.CENTER_RIGHT,
+        style: googleMaps.ZoomControlStyle.SMALL,
       },
-    ],
-  }
+      styles: [
+        {
+          featureType: 'poi',
+          stylers: [{ visibility: 'off' }],
+        },
+      ],
+    }
+  }, [
+    googleMaps.ControlPosition.CENTER_RIGHT,
+    googleMaps.ZoomControlStyle.SMALL,
+  ])
 
-  const setMap = () => {
+  const setMap = useCallback(() => {
     const location = getLocation(geoCoordinates)
+
     map = new googleMaps.Map(mapDiv.current, {
       center: location,
       ...mapOptions,
@@ -86,13 +105,19 @@ const Map: FunctionComponent<MapProps> = ({ googleMaps, geoCoordinates }) => {
     marker = new googleMaps.Marker(markerOptions)
 
     marker.setPosition(location)
-  }
+  }, [
+    geoCoordinates,
+    getLocation,
+    googleMaps.Map,
+    googleMaps.Marker,
+    mapOptions,
+  ])
 
   useEffect(() => {
     if (!mapDiv.current || last === geoCoordinates.join('')) return
     setLast(geoCoordinates.join(''))
     setMap()
-  }, [mapDiv, geoCoordinates])
+  }, [mapDiv, geoCoordinates, last, setMap])
 
   if (!googleMaps || !geoCoordinates.length) return null
 

--- a/react/helpers/getParsedAddress.tsx
+++ b/react/helpers/getParsedAddress.tsx
@@ -1,6 +1,9 @@
-import { path } from 'ramda'
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 const getCountryISO3 = require('country-iso-2-to-3')
+
 /**
  * The place object returned from Google Maps API has some extra informations about the address that won't be used when sending
  * to orderform. So, this function will reduce nested address information into a simpler consumable object.
@@ -8,22 +11,26 @@ const getCountryISO3 = require('country-iso-2-to-3')
  * @param {Object} place The place object returned from Google Maps API
  * @returns {Object} The reduced address data with only necessary fields/information
  */
-export const getParsedAddress = (place: { address_components: any[] }) => {
+export const getParsedAddress = (place: {
+  address_components: any[]
+  geometry: any
+}) => {
   const parsedAddressComponents = place.address_components.reduce(
     (accumulator, address) => {
       const parsedItem = address.types.reduce(
-        (accumulator: any, type: any) => ({
-          ...accumulator,
+        (typeAccumulator: any, type: any) => ({
+          ...typeAccumulator,
           [type]: address.short_name,
         }),
         {}
       )
+
       return { ...accumulator, ...parsedItem }
     },
     {}
   )
 
-  const { lat, lng } = path(['geometry', 'location'], place) || {}
+  const { lat, lng } = place.geometry?.location ?? {}
   // lat and lng may come as a function or a double
   const latitude = typeof lat === 'function' ? lat() : lat
   const longitude = typeof lng === 'function' ? lng() : lng
@@ -32,8 +39,8 @@ export const getParsedAddress = (place: { address_components: any[] }) => {
     addressType: 'residential',
     city:
       parsedAddressComponents.administrative_area_level_3 ||
-      parsedAddressComponents.administrative_area_level_2 ||
-      parsedAddressComponents.locality,
+      parsedAddressComponents.locality ||
+      parsedAddressComponents.administrative_area_level_2,
     // complement: '',
     /* Google Maps API returns Alpha-2 ISO codes, but checkout API requires Alpha-3 */
     country: getCountryISO3(parsedAddressComponents.country),
@@ -44,7 +51,7 @@ export const getParsedAddress = (place: { address_components: any[] }) => {
     state: parsedAddressComponents.administrative_area_level_1,
     street: `${
       parsedAddressComponents.street_number
-        ? parsedAddressComponents.street_number + ' '
+        ? `${parsedAddressComponents.street_number} `
         : ''
     }${parsedAddressComponents.route}`,
     geoCoordinates: latitude && longitude ? [longitude, latitude] : null,

--- a/react/helpers/getParsedAddress.tsx
+++ b/react/helpers/getParsedAddress.tsx
@@ -38,8 +38,8 @@ export const getParsedAddress = (place: {
   const address = {
     addressType: 'residential',
     city:
-      parsedAddressComponents.administrative_area_level_3 ||
       parsedAddressComponents.locality ||
+      parsedAddressComponents.administrative_area_level_3 ||
       parsedAddressComponents.administrative_area_level_2,
     // complement: '',
     /* Google Maps API returns Alpha-2 ISO codes, but checkout API requires Alpha-3 */

--- a/react/package.json
+++ b/react/package.json
@@ -8,7 +8,6 @@
     "apollo-link": "^1.2.14",
     "apollo-utilities": "^1.3.4",
     "country-iso-2-to-3": "^1.1.0",
-    "ramda": "^0.27.1",
     "react": "^16.8.3",
     "react-apollo": "^3.1.5",
     "react-dom": "^16.8.3",
@@ -18,7 +17,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/node": "^12.12.7",
-    "@types/ramda": "^0.27.14",
     "@types/react": "^16.8.10",
     "@types/react-intl": "^3.0.0",
     "@vtex/test-tools": "^0.2.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1293,13 +1293,6 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/ramda@^0.27.14":
-  version "0.27.14"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.27.14.tgz#95f5f676ebdff89cbc7ded8cd011911fa6854daf"
-  integrity sha512-vbw/VAtEJeSJ6Z61QT+epirlnBeJiJIO7ndK1BJ0fKswnfbiTNga/jBG6R3OnBaFYx+UJv6Iv7ZfWDFSsSzNqA==
-  dependencies:
-    ts-toolbelt "^6.3.3"
-
 "@types/react-intl@^2.3.17":
   version "2.3.18"
   resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-2.3.18.tgz#fd2d8b7f4d0a1dd05b5f1784ab0d7fe1786a690d"
@@ -3815,11 +3808,6 @@ ramda@^0.26.1:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
-ramda@^0.27.1:
-  version "0.27.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
-  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
-
 react-apollo@^2.5.2:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.8.tgz#c7a593b027efeefdd8399885e0ac6bec3b32623c"
@@ -4509,11 +4497,6 @@ ts-invariant@^0.4.0, ts-invariant@^0.4.2, ts-invariant@^0.4.4:
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
     tslib "^1.9.3"
-
-ts-toolbelt@^6.3.3:
-  version "6.15.5"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
-  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 tslib@^1.10.0, tslib@^1.9.3:
   version "1.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,29 +70,30 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@typescript-eslint/eslint-plugin@^2.17.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
-  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
+"@typescript-eslint/eslint-plugin@^3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.10.1.tgz#7e061338a1383f59edc204c605899f93dc2e2c8f"
+  integrity sha512-PQg0emRtzZFWq6PxBcdxRH3QIQiyFO3WCVpRL3fgj5oQS3CDs3AeAKfv4DxNhzn8ITdNJGJ4D3Qw8eAJf3lXeQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/eslint-plugin@^3.9.1":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.10.0.tgz#40fd53e81639c0d1a515b44e5fdf4c03dfd3cd39"
-  integrity sha512-Bbeg9JAnSzZ85Y0gpInZscSpifA6SbEgRryaKdP5ZlUjhTKsvZS4GUIE6xAZCjhNTrf4zXXsySo83ZdHL7it0w==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "3.10.0"
+    "@typescript-eslint/experimental-utils" "3.10.1"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.34.0", "@typescript-eslint/experimental-utils@^2.5.0":
+"@typescript-eslint/experimental-utils@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
+  integrity sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/types" "3.10.1"
+    "@typescript-eslint/typescript-estree" "3.10.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/experimental-utils@^2.5.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
   integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
@@ -102,42 +103,21 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/experimental-utils@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.0.tgz#f97a669a84a78319ab324cd51169d0c52853a360"
-  integrity sha512-e5ZLSTuXgqC/Gq3QzK2orjlhTZVXzwxDujQmTBOM1NIVBZgW3wiIZjaXuVutk9R4UltFlwC9UD2+bdxsA7yyNg==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/types" "3.10.0"
-    "@typescript-eslint/typescript-estree" "3.10.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
-"@typescript-eslint/parser@^2.17.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
-  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
+"@typescript-eslint/parser@^3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.10.1.tgz#1883858e83e8b442627e1ac6f408925211155467"
+  integrity sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    "@typescript-eslint/typescript-estree" "2.34.0"
+    "@typescript-eslint/experimental-utils" "3.10.1"
+    "@typescript-eslint/types" "3.10.1"
+    "@typescript-eslint/typescript-estree" "3.10.1"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/parser@^3.8.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.10.0.tgz#820322d990a82265a78f4c1fc9aae03ce95b76ac"
-  integrity sha512-iJyf3f2HVwscvJR7ySGMXw2DJgIAPKEz8TeU17XVKzgJRV4/VgCeDFcqLzueRe7iFI2gv+Tln4AV88ZOnsCNXg==
-  dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "3.10.0"
-    "@typescript-eslint/types" "3.10.0"
-    "@typescript-eslint/typescript-estree" "3.10.0"
-    eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/types@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.0.tgz#b81906674eca94a884345ba0bc1aaf6cd4da912a"
-  integrity sha512-ktUWSa75heQNwH85GRM7qP/UUrXqx9d6yIdw0iLO9/uE1LILW+i+3+B64dUodUS2WFWLzKTlwfi9giqrODibWg==
+"@typescript-eslint/types@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
+  integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
 
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
@@ -152,13 +132,13 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.0.tgz#65df13579a5e53c12afb4f1c5309589e3855a5de"
-  integrity sha512-yjuY6rmVHRhcUKgXaSPNVloRueGWpFNhxR5EQLzxXfiFSl1U/+FBqHhbaGwtPPEgCSt61QNhZgiFjWT27bgAyw==
+"@typescript-eslint/typescript-estree@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz#fd0061cc38add4fad45136d654408569f365b853"
+  integrity sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==
   dependencies:
-    "@typescript-eslint/types" "3.10.0"
-    "@typescript-eslint/visitor-keys" "3.10.0"
+    "@typescript-eslint/types" "3.10.1"
+    "@typescript-eslint/visitor-keys" "3.10.1"
     debug "^4.1.1"
     glob "^7.1.6"
     is-glob "^4.0.1"
@@ -166,10 +146,10 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.0.tgz#6c0cac867e705a42e2c71b359bf6a10a88a28985"
-  integrity sha512-g4qftk8lWb/rHZe9uEp8oZSvsJhUvR2cfp7F7qE6DyUD2SsovEs8JDQTRP1xHzsD+pERsEpYNqkDgQXW6+ob5A==
+"@typescript-eslint/visitor-keys@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
+  integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
@@ -650,52 +630,37 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-prettier@^6.11.0, eslint-config-prettier@^6.9.0:
+eslint-config-prettier@^6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
   integrity sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-vtex-react@6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-6.2.1.tgz#adb4b513a136381831edb64ae8f64af170670af6"
-  integrity sha512-/pprgWmK6EkKjgQ2zMKVKGsHB9dKr7nlj4WufD1YreuSg+y78xHNTp7WmsL8Vf1OQfyeG8Tvn1UZqV2KGX8XYQ==
+eslint-config-vtex-react@^6.7.0:
+  version "6.7.8"
+  resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-6.7.8.tgz#267bd4d0132fcb0d931371677b6d29981d2d40f9"
+  integrity sha512-SsMBy98Lm5b/84T8Awr8tBSLBPf0YJ+i8/mL7+MQezyStUYbFbDLcD6kS4jtoW0UgHWQI6wRp1JG2eokEXsNZg==
   dependencies:
-    eslint-config-vtex "^12.2.1"
-    eslint-plugin-jsx-a11y "^6.2.3"
-    eslint-plugin-react "^7.18.0"
-    eslint-plugin-react-hooks "^2.3.0"
+    eslint-config-vtex "^12.8.6"
+    eslint-plugin-jsx-a11y "^6.3.1"
+    eslint-plugin-react "^7.20.6"
+    eslint-plugin-react-hooks "^4.1.0"
 
-eslint-config-vtex@12.2.1:
-  version "12.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.2.1.tgz#b995954240f795a0bb07450dc467430d9da03a6b"
-  integrity sha512-ueMkiSvB89enh9UrWREwsgMvV+2lZlhbLLMqUrZFyzbJ0+ulB2qzNMgFANa1Az8i/xjUtIgBuRPjL5BHwWkw3g==
+eslint-config-vtex@^12.7.0, eslint-config-vtex@^12.8.6:
+  version "12.8.6"
+  resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.8.6.tgz#be2ce1656a4b177749e5882d70cef0c32847623d"
+  integrity sha512-vCMylWm669AhayvqxPc96YD9EN1YpCuoVlyBpzAPDOUch3+wOL7Y7pkh/4f5TzZLe1EwPFpUMkeL20A/6JFGDw==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "^2.17.0"
-    "@typescript-eslint/parser" "^2.17.0"
-    confusing-browser-globals "^1.0.9"
-    eslint-config-prettier "^6.9.0"
-    eslint-plugin-cypress "^2.9.0"
-    eslint-plugin-import "^2.20.0"
-    eslint-plugin-jest "^23.7.0"
-    eslint-plugin-prettier "^3.1.2"
-    eslint-plugin-vtex "^1.0.3"
-
-eslint-config-vtex@^12.2.1:
-  version "12.8.5"
-  resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.8.5.tgz#8214ce0fc138fb26afd84e3cf33cc44916049038"
-  integrity sha512-/uh3zjbFMFyfFT9KVcEfs793nT1v8TdnzfypTZOM5fgrmSVFws3UdHgG88gAQUDCOn9d/EMQDDRw9sTVHrAhLA==
-  dependencies:
-    "@typescript-eslint/eslint-plugin" "^3.9.1"
-    "@typescript-eslint/parser" "^3.8.0"
+    "@typescript-eslint/eslint-plugin" "^3.10.1"
+    "@typescript-eslint/parser" "^3.10.1"
     confusing-browser-globals "^1.0.9"
     eslint-config-prettier "^6.11.0"
     eslint-plugin-cypress "^2.11.1"
     eslint-plugin-import "^2.22.0"
     eslint-plugin-jest "^23.20.0"
     eslint-plugin-prettier "^3.1.4"
-    eslint-plugin-vtex "^2.0.2"
+    eslint-plugin-vtex "^2.0.3"
 
 eslint-import-resolver-node@^0.3.3:
   version "0.3.4"
@@ -713,14 +678,14 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-cypress@^2.11.1, eslint-plugin-cypress@^2.9.0:
+eslint-plugin-cypress@^2.11.1:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.11.1.tgz#a945e2774b88211e2c706a059d431e262b5c2862"
   integrity sha512-MxMYoReSO5+IZMGgpBZHHSx64zYPSPTpXDwsgW7ChlJTF/sA+obqRbHplxD6sBStE+g4Mi0LCLkG4t9liu//mQ==
   dependencies:
     globals "^11.12.0"
 
-eslint-plugin-import@^2.20.0, eslint-plugin-import@^2.22.0:
+eslint-plugin-import@^2.22.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
   integrity sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
@@ -739,14 +704,14 @@ eslint-plugin-import@^2.20.0, eslint-plugin-import@^2.22.0:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-plugin-jest@^23.20.0, eslint-plugin-jest@^23.7.0:
+eslint-plugin-jest@^23.20.0:
   version "23.20.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz#e1d69c75f639e99d836642453c4e75ed22da4099"
   integrity sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
-eslint-plugin-jsx-a11y@^6.2.3:
+eslint-plugin-jsx-a11y@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz#99ef7e97f567cc6a5b8dd5ab95a94a67058a2660"
   integrity sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==
@@ -763,22 +728,22 @@ eslint-plugin-jsx-a11y@^6.2.3:
     jsx-ast-utils "^2.4.1"
     language-tags "^1.0.5"
 
-eslint-plugin-prettier@^3.1.2, eslint-plugin-prettier@^3.1.4:
+eslint-plugin-prettier@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
   integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@^2.3.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz#4ef5930592588ce171abeb26f400c7fbcbc23cd0"
-  integrity sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==
+eslint-plugin-react-hooks@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.2.tgz#2eb53731d11c95826ef7a7272303eabb5c9a271e"
+  integrity sha512-ykUeqkGyUGgwTtk78C0o8UG2fzwmgJ0qxBGPp2WqRKsTwcLuVf01kTDRAtOsd4u6whX2XOC8749n2vPydP82fg==
 
-eslint-plugin-react@^7.18.0:
-  version "7.20.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz#4d7845311a93c463493ccfa0a19c9c5d0fd69f60"
-  integrity sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==
+eslint-plugin-react@^7.20.6:
+  version "7.21.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.2.tgz#3bd5d2c4c36d5a0428d0d6dda301ac9a84d681b2"
+  integrity sha512-j3XKvrK3rpBzveKFbgAeGsWb9uz6iUOrR0jixRfjwdFeGSRsXvVTFtHDQYCjsd1/6Z/xvb8Vy3LiI5Reo7fDrg==
   dependencies:
     array-includes "^3.1.1"
     array.prototype.flatmap "^1.2.3"
@@ -792,15 +757,10 @@ eslint-plugin-react@^7.18.0:
     resolve "^1.17.0"
     string.prototype.matchall "^4.0.2"
 
-eslint-plugin-vtex@^1.0.3:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vtex/-/eslint-plugin-vtex-1.2.1.tgz#4cb26d5844a50250c0d65f1d1444db85fdf1c406"
-  integrity sha512-YJ07HC0vXtl2VXn0gRIutNww1uuMWmyV/8ERsLfB6AqLRwWF8+6vran84RuPXtV5u4aqhtOejw2XAn2Omtk7IA==
-
-eslint-plugin-vtex@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vtex/-/eslint-plugin-vtex-2.0.2.tgz#d47afb271a682ebd7839bfe30f57e13b84902d9f"
-  integrity sha512-B+hnxl05Wu9wtVHKxWSiOz0R079qpxuxEro6t9kWwxlEC7gUiKdAATzWpFXNly7tpTYxsxvYuHLw5WJWoONNVA==
+eslint-plugin-vtex@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vtex/-/eslint-plugin-vtex-2.0.3.tgz#78b6759f29a9926f48b518a18299d9603a619565"
+  integrity sha512-irSDajtTcpuvTwRIxmcdY/9uwWqfLcQtniN/NcgVLavGTshgSz0t0MQ0bulFiP2t+noXQltJnz9ocgfEVtJhzw==
 
 eslint-scope@^5.0.0:
   version "5.1.0"


### PR DESCRIPTION
New version linked here: https://geo3--eriksbikeshop.myvtex.com

This PR changes the order of priority in the Google Places API response of the fields that could contain the shopper's city.

The new priority is:
1. "locality"
2. "administrative_area_level_3"
3. "administrative_area_level_2"
If the first value is null or empty, the next one in the list is used. 

This PR also adds a maxWidth styling to the error message that can sometimes be displayed when the shopper uses the "Find My Location" button (previously the error message could break the form layout).

Also as part of this PR I updated the eslint package and linted the code using the newer rules.