### PR TITLE
Add Client Redirect option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Optional client redirect based on location
+
 ## [0.1.4] - 2020-09-25
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ A block is also provided which renders a form allowing the user to manually chan
 
 2. In your account's admin dashboard, go to `Apps > My Apps` and click the Settings button for Shopper Location.
 
-3. Enter your API key for https://ip-geolocation.whoisxmlapi.com in the provided field and click Save.
+3. Enter your API key for https://ip-geolocation.whoisxmlapi.com in the provided field and click Save. If you plan to use the `Client Redirect` feature, it is also configured here.
 
 4. Modify your `store-theme` as follows:
 
@@ -97,6 +97,14 @@ A block is also provided which renders a form allowing the user to manually chan
     ]
   },
 ```
+
+### Client Redirect
+
+You have the option to redirect the user to a country specific URL, based on the user's location. In the App Settings, enter the [alpha-3 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#Officially_assigned_code_elements) and URL for each supported country.
+
+On their first visit, if a user is not on their country's website, they will be given the option to be redirected to their country specific website. For users located in a country that does not have an entry in the App Settings, no option is displayed.
+
+Additionally, there is an `Automatic Redirect` option, that will redirect the user automatically, without displaying the option.
 
 ## Customization
 

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,31 @@
         "title": "IP Geolocation Service API Key",
         "description": "Enter your API key for https://ip-geolocation.whoisxmlapi.com",
         "type": "string"
+      },
+      "redirects": {
+        "title": "Locale Redirect",
+        "description": "Redirect requests based off user location",
+        "type": "array",
+        "items": {
+          "default": [],
+          "type": "object",
+          "properties": {
+            "country": {
+              "title": "Alpha-3 Country Code",
+              "type": "string"
+            },
+            "url": {
+              "title": "URL",
+              "type": "string"
+            }
+          }
+        }
+      },
+      "automaticRedirect": {
+        "title": "Automatic Redirect",
+        "description": "Redirect user to their country site without displaying a redirect message and option",
+        "type": "boolean",
+        "default": false
       }
     }
   },

--- a/messages/context.json
+++ b/messages/context.json
@@ -5,6 +5,7 @@
   "store/shopper-location.change-location.error-country": "store/shopper-location.change-location.error-country",
   "store/shopper-location.change-location.error-permission": "store/shopper-location.change-location.error-permission",
   "store/shopper-location.change-location.submit": "store/shopper-location.change-location.submit",
+  "store/shopper-location.redirect-toast.message": "store/shopper-location.redirect-toast.message",
 
   "store/shopper-location.countries.ABW": "store/shopper-location.countries.ABW",
   "store/shopper-location.countries.AFG": "store/shopper-location.countries.AFG",

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,6 +5,7 @@
   "store/shopper-location.change-location.error-country": "Sorry, shipping is not available for your location.",
   "store/shopper-location.change-location.error-permission": "Failed to find your location. Please check that you have granted permission for this site to use your location.",
   "store/shopper-location.change-location.submit": "SAVE",
+  "store/shopper-location.redirect-toast.message": "Switch to the {country} site, if you would like to view the {country} specific site and products.",
 
   "store/shopper-location.countries.ABW": "Aruba",
   "store/shopper-location.countries.AFG": "Afghanistan",

--- a/react/components/RedirectToast.tsx
+++ b/react/components/RedirectToast.tsx
@@ -1,0 +1,88 @@
+import React, { FunctionComponent, useState } from 'react'
+import { ToastConsumer } from 'vtex.styleguide'
+
+interface RedirectToastProps {
+  intl: any
+  orderForm: any
+  appSettings?: SettingsData
+}
+
+const RedirectToast: FunctionComponent<RedirectToastProps> = ({
+  intl,
+  orderForm,
+  appSettings,
+}) => {
+  const [redirectTo, setRedirectTo] = useState<string | null>(null)
+  const hasCookie = document.cookie
+    .split('; ')
+    .find(row => row.startsWith('VtexShopperLocation'))
+
+  const setCookie = () =>
+    (document.cookie = `VtexShopperLocation=1;path=/;max-age=7890000`)
+
+  if (!orderForm.shippingData?.address || !appSettings || hasCookie) {
+    return null
+  }
+
+  const settings = JSON.parse(appSettings.message) as Settings
+  const { redirects } = settings
+
+  if (redirects && !redirectTo) {
+    const countryRedirect = redirects.find(
+      redirect => redirect.country === orderForm.shippingData.address.country
+    )
+
+    if (
+      !countryRedirect?.url ||
+      window.location.href.includes(countryRedirect.url)
+    ) {
+      return null
+    }
+
+    if (settings.automaticRedirect) {
+      setCookie()
+      window.location.href = countryRedirect.url
+
+      return null
+    }
+
+    setRedirectTo(countryRedirect.url)
+  }
+
+  const toastMessage = () => {
+    const country = intl.formatMessage({
+      id: `store/shopper-location.countries.${orderForm.shippingData.address.country}`,
+    })
+
+    return intl.formatMessage(
+      {
+        id: 'store/shopper-location.redirect-toast.message',
+      },
+      {
+        country,
+      }
+    )
+  }
+
+  return (
+    <ToastConsumer>
+      {(toast: any) => {
+        toast.showToast({
+          message: toastMessage(),
+          horizontalPosition: 'right',
+          duration: 20000,
+          action: {
+            label: 'Switch',
+            href: redirectTo,
+            target: '_self',
+          },
+        })
+
+        setRedirectTo(null)
+        setCookie()
+      }}
+    </ToastConsumer>
+  )
+}
+
+export default RedirectToast

--- a/react/components/RedirectToast.tsx
+++ b/react/components/RedirectToast.tsx
@@ -27,7 +27,9 @@ const RedirectToast: FunctionComponent<RedirectToastProps> = ({
   const settings = JSON.parse(appSettings.message) as Settings
   const { redirects } = settings
 
-  if (redirects && !redirectTo) {
+  if (!redirects) return null
+
+  if (!redirectTo) {
     const countryRedirect = redirects.find(
       redirect => redirect.country === orderForm.shippingData.address.country
     )

--- a/react/package.json
+++ b/react/package.json
@@ -12,7 +12,7 @@
     "react-apollo": "^3.1.5",
     "react-dom": "^16.8.3",
     "react-intl": "^5.8.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -7,5 +7,22 @@ declare global {
       postalCodeAutoCompleted?: boolean
     }
   }
+
+  interface AppSettingsData {
+    appSettings: SettingsData
+  }
+
+  interface SettingsData {
+    message: string
+  }
+  interface Settings {
+    geolocationApiKey: string
+    redirects: Redirect[]
+    automaticRedirect: boolean
+  }
+  interface Redirect {
+    country: string
+    url: string
+  }
 }
 export {}

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -10,6 +10,8 @@ declare module 'vtex.styleguide' {
   export const Spinner: ComponentType<Props>
   export const Dropdown: ComponentType<Props>
   export const Checkbox: ComponentType<Props>
+  export const ToastConsumer: ComponentType<Props>
+  export const ToastProvider: ComponentType<Props>
   export const Toggle: ComponentType<Props>
   export const Divider: ComponentType<Props>
   export const IconCheck: ComponentType<Props>

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4522,12 +4522,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.3.3333:
+typescript@3.9.7, typescript@^3.3.3333:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
Implements an option to have the client redirected to a country specific URL based on the client location. A cookie is used to limit the redirect message to the first visit.   

![Peek 2020-11-13 15-10](https://user-images.githubusercontent.com/22715037/99117767-4f594400-25c4-11eb-98a2-2c1afd3f8c61.gif)

![Screenshot from 2020-11-13 15-11-16](https://user-images.githubusercontent.com/22715037/99117807-60a25080-25c4-11eb-911a-23b4be34e0c6.png)


Testing:

[US workspace](https://sdb--sandboxusdev.myvtex.com/)
[BR workspace](https://sdbbr--sandboxusdev.myvtex.com/)