### PR TITLE
Ignore country letter casing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,10 @@ This app attempts to determine the user's location if not already known, first b
 
 A block is also provided which renders a form allowing the user to manually change their location.
 
-:warning: You must have an API key for https://ip-geolocation.whoisxmlapi.com in order to use the IP lookup fallback method.
+Shopper Location also supports redirecting a user to a URL based off their location determined by the app. See the [Client Redirect](#client-redirect) section.
+
+:information_source: The Google Geolocation API key in your _Inventory & Shipping_ settings is required for the geolocation feature.
+:warning: To use the IP lookup fallback, you must have an API key for https://ip-geolocation.whoisxmlapi.com.
 
 ## Configuration
 
@@ -29,7 +32,7 @@ A block is also provided which renders a form allowing the user to manually chan
 ```json
     "vtex.store-components": "3.x",
     "vtex.modal-layout": "0.x",
-    "vtex.shopper-location": "0.x"
+    "vtex.shopper-location": "1.x"
 ```
 
 - In one of the JSON files in your theme's `store` folder, define the `shopper-location` block and its children, adjusting the props as needed:
@@ -102,9 +105,9 @@ A block is also provided which renders a form allowing the user to manually chan
 
 You have the option to redirect the user to a country specific URL, based on the user's location. In the App Settings, enter the [alpha-3 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#Officially_assigned_code_elements) and URL for each supported country.
 
-On their first visit, if a user is not on their country's website, they will be given the option to be redirected to their country specific website. For users located in a country that does not have an entry in the App Settings, no option is displayed.
+On their first visit, if a user is not on their country's website, a modal will display an option to be redirected to their country specific website. For users located in a country that does not have an entry in the App Settings, no option is displayed.
 
-Additionally, there is an `Automatic Redirect` option, that will redirect the user automatically, without displaying the option.
+Additionally, there is an `Automatic Redirect` option, that will redirect the user automatically, without displaying the modal.
 
 ## Customization
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,7 +5,7 @@
   "store/shopper-location.change-location.error-country": "Sorry, shipping is not available for your location.",
   "store/shopper-location.change-location.error-permission": "Failed to find your location. Please check that you have granted permission for this site to use your location.",
   "store/shopper-location.change-location.submit": "SAVE",
-  "store/shopper-location.redirect-toast.message": "Switch to the {country} site, if you would like to view the {country} specific site and products.",
+  "store/shopper-location.redirect-toast.message": "Switch to the {country} website.",
   "store/shopper-location.change-location.street": "Street address or P.O. Box",
   "store/shopper-location.change-location.street-placeholder": "Eg: 225 East 41st Street, New York",
   "store/shopper-location.change-location.apartment": "Apartment, suite, building, floor, etc (optional)",

--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "@types/jest": "^24.0.18",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.39.1",
+    "@vtex/api": "6.40.0",
     "@vtex/test-tools": "^1.0.0",
     "@vtex/tsconfig": "^0.5.6",
     "typescript": "3.9.7"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1447,10 +1447,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.2.tgz#808c9fa7e4517274ed555fa158f2de4b4f468e71"
   integrity sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==
 
-"@vtex/api@6.39.1":
-  version "6.39.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.1.tgz#ad675cf46404b0d21476ac441626843b6950c4a2"
-  integrity sha512-w3FghXguk4b+bOSOihB8I4+gGt7JljRCXFgirK9XiHDOr+uPsUEGhC4JeeQ42aBIEQeyGmQQOsyvZ+qZp2C/oA==
+"@vtex/api@6.40.0":
+  version "6.40.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.40.0.tgz#830c4aaaad75a1a8cf86ce898010e081a89053f8"
+  integrity sha512-VDdg9KVoNQ6KxH6cM0Tgh+VF7ELLrORqk5lRaie4akUZXW2tqECFLZAvRi9UE29CLstqCLBGQjqxbuT1aj/mgQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -5300,7 +5300,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/RedirectToast.tsx
+++ b/react/components/RedirectToast.tsx
@@ -19,7 +19,9 @@ const RedirectToast: FunctionComponent<RedirectToastProps &
   const setCookie = () =>
     (document.cookie = `VtexShopperLocation=1;path=/;max-age=7890000`)
 
-  if (!orderForm.shippingData?.address || !appSettings || hasCookie) {
+  const orderFormCountry = orderForm.shippingData?.address?.country
+
+  if (!orderFormCountry || !appSettings || hasCookie) {
     return null
   }
 
@@ -30,7 +32,8 @@ const RedirectToast: FunctionComponent<RedirectToastProps &
 
   if (!redirectTo) {
     const countryRedirect = redirects.find(
-      redirect => redirect.country === orderForm.shippingData.address.country
+      redirect =>
+        redirect.country.toUpperCase() === orderFormCountry.toUpperCase()
     )
 
     if (


### PR DESCRIPTION
Updates to the documentation and a fix to the redirect feature.

For the redirect, a lower-case country code entered in the settings was not matching the upper-case country code found in the orderForm.