### PR TITLE
Feature/location 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Selected address not showing up on the form
 ### Added
 - Custom autofill, define which address fields will be filled with the property `autofill` on the `shopper-location` interface
 - Autocomplete address based on the postalCode using Google's API, can be set for the `change-location` interface
 - Adjust postalCode position at the form , can be set for the `change-location` interface
+- `notRequired` and `hideFields` can be set on the `change-location` interface
 ## [1.2.0] - 2021-04-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Custom autofill, define which address fields will be filled with the property `autofill` on the `shopper-location` interface
+- Autocomplete address based on the postalCode using Google's API, can be set for the `change-location` interface
+- Adjust postalCode position at the form , can be set for the `change-location` interface
 ## [1.2.0] - 2021-04-23
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,7 +80,9 @@ Shopper Location also supports redirecting a user to a URL based off their locat
   "change-location": {
 		"props":{
       "postalCode": "first",
-			"autocomplete": true
+			"autocomplete": true,
+      "notRequired": ["street", "number", "city", "state"],
+      "hideFields": ["complement", "neighborhood", "receiverName", "reference"]
     }
 	},
 ```
@@ -122,16 +124,18 @@ Additionally, there is an `Automatic Redirect` option, that will redirect the us
 
 `shopper-location`:
 
-| Prop name  | Type   | Description                                  | Default value | Accepted values                                                                                                 |
-| ---------- | ------ | -------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------- |
-| `autofill` | `enum` | Define which address fields should be filled | `undefined`   | Array with any of these values `["city", "country", "neighborhood", "number", "postalCode", "state", "street"]` |
+| Prop name  | Type    | Description                                  | Default value | Accepted values                                                                                                 |
+| ---------- | ------- | -------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `autofill` | `array` | Define which address fields should be filled | `undefined`   | Array with any of these values `["city", "country", "neighborhood", "number", "postalCode", "state", "street"]` |
 
 `change-location`:
 
-| Prop name      | Type      | Description                                         | Default value | Accepted values |
-| -------------- | --------- | --------------------------------------------------- | ------------- | --------------- |
-| `postalCode`   | `string`  | Define the postalCode position on the form          | `last`        | `first`,`last`  |
-| `autocomplete` | `boolean` | Enables google autocomplete based on the postalCode | `false`       | `true`,`false`  |
+| Prop name      | Type      | Description                                         | Default value | Accepted values                                                                                              |
+| -------------- | --------- | --------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------ |
+| `postalCode`   | `string`  | Define the postalCode position on the form          | `last`        | `first`,`last`                                                                                               |
+| `autocomplete` | `boolean` | Enables google autocomplete based on the postalCode | `false`       | `true`,`false`                                                                                               |
+| `notRequired`  | `array`   | Turn visible fields not required                    | `undefined`   | `["city", "country", "neighborhood", "number", "state", "street", "complement","receiverName", "reference"]` |
+| `hideFields`   | `array`   | Hide fields and turn them not required              | `undefined`   | `["city", "country", "neighborhood", "number", "state", "street", "complement","receiverName", "reference"]` |
 
 ## Customization
 
@@ -143,6 +147,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `changeLocationContainer`         |
 | `changeLocationFormContainer`     |
 | `changeLocationGeoContainer`      |
+| `changeLocationMapContainer`      |
 | `changeLocationGeoErrorContainer` |
 | `changeLocationGeolocationButton` |
 | `changeLocationSubmitContainer`   |

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,7 +133,7 @@ Additionally, there is an `Automatic Redirect` option, that will redirect the us
 | Prop name      | Type      | Description                                         | Default value | Accepted values                                                                                              |
 | -------------- | --------- | --------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------ |
 | `postalCode`   | `string`  | Define the postalCode position on the form          | `last`        | `first`,`last`                                                                                               |
-| `autocomplete` | `boolean` | Enables google autocomplete based on the postalCode | `false`       | `true`,`false`                                                                                               |
+| `autocomplete` | `boolean` | Enables google autocomplete based on the postalCode (Only works when **postalCode** is set to `first`) | `false`       | `true`,`false`                                                                                               |
 | `notRequired`  | `array`   | Turn visible fields not required                    | `undefined`   | `["city", "country", "neighborhood", "number", "state", "street", "complement","receiverName", "reference"]` |
 | `hideFields`   | `array`   | Hide fields and turn them not required              | `undefined`   | `["city", "country", "neighborhood", "number", "state", "street", "complement","receiverName", "reference"]` |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ A block is also provided which renders a form allowing the user to manually chan
 
 Shopper Location also supports redirecting a user to a URL based off their location determined by the app. See the [Client Redirect](#client-redirect) section.
 
-:information_source: The Google Geolocation API key in your _Inventory & Shipping_ settings is required for the geolocation feature.
+:information*source: The Google Geolocation API key in your \_Inventory & Shipping* settings is required for the geolocation feature.
 :warning: To use the IP lookup fallback, you must have an API key for https://ip-geolocation.whoisxmlapi.com.
 
 ## Configuration
@@ -39,7 +39,10 @@ Shopper Location also supports redirecting a user to a URL based off their locat
 
 ```json
 "shopper-location": {
-    "children": ["modal-trigger#address"]
+    "children": ["modal-trigger#address"],
+    "props": {
+      "autofill": ["city", "country", "neighborhood", "number", "postalCode", "state", "street"]
+    }
   },
   "modal-trigger#address": {
     "children": ["user-address", "modal-layout#address"]
@@ -74,6 +77,12 @@ Shopper Location also supports redirecting a user to a URL based off their locat
   "modal-content#address": {
     "children": ["change-location"]
   },
+  "change-location": {
+		"props":{
+      "postalCode": "first",
+			"autocomplete": true
+    }
+	},
 ```
 
 - Also in one of the JSON files, place the `shopper-location` block in your layout. For example, to place the block in the header:
@@ -108,6 +117,21 @@ You have the option to redirect the user to a country specific URL, based on the
 On their first visit, if a user is not on their country's website, a modal will display an option to be redirected to their country specific website. For users located in a country that does not have an entry in the App Settings, no option is displayed.
 
 Additionally, there is an `Automatic Redirect` option, that will redirect the user automatically, without displaying the modal.
+
+#### Props
+
+`shopper-location`:
+
+| Prop name  | Type   | Description                                  | Default value | Accepted values                                                                                                 |
+| ---------- | ------ | -------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `autofill` | `enum` | Define which address fields should be filled | `undefined`   | Array with any of these values `["city", "country", "neighborhood", "number", "postalCode", "state", "street"]` |
+
+`change-location`:
+
+| Prop name      | Type      | Description                                         | Default value | Accepted values |
+| -------------- | --------- | --------------------------------------------------- | ------------- | --------------- |
+| `postalCode`   | `string`  | Define the postalCode position on the form          | `last`        | `first`,`last`  |
+| `autocomplete` | `boolean` | Enables google autocomplete based on the postalCode | `false`       | `true`,`false`  |
 
 ## Customization
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "shopper-location",
   "vendor": "vtex",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "title": "Shopper Location",
   "description": "Determine location of shopper and store it in the orderForm",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "shopper-location",
   "vendor": "vtex",
-  "version": "1.3.0-beta.0",
+  "version": "1.3.0-beta.1",
   "title": "Shopper Location",
   "description": "Determine location of shopper and store it in the orderForm",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "shopper-location",
   "vendor": "vtex",
-  "version": "1.2.0",
+  "version": "1.3.0-beta.0",
   "title": "Shopper Location",
   "description": "Determine location of shopper and store it in the orderForm",
   "builders": {
@@ -63,9 +63,7 @@
       "url": "https://help-tickets.vtex.com/en/support?app=vtex.shopper-location"
     },
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "policies": [
     {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "shopper-location",
   "vendor": "vtex",
-  "version": "1.3.0-beta.2",
+  "version": "1.3.0-beta.3",
   "title": "Shopper Location",
   "description": "Determine location of shopper and store it in the orderForm",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -63,7 +63,9 @@
       "url": "https://help-tickets.vtex.com/en/support?app=vtex.shopper-location"
     },
     "type": "free",
-    "availableCountries": ["*"]
+    "availableCountries": [
+      "*"
+    ]
   },
   "policies": [
     {

--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "@types/jest": "^24.0.18",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.40.0",
+    "@vtex/api": "6.42.1",
     "@vtex/test-tools": "^1.0.0",
     "@vtex/tsconfig": "^0.5.6",
     "typescript": "3.9.7"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1447,10 +1447,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.2.tgz#808c9fa7e4517274ed555fa158f2de4b4f468e71"
   integrity sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==
 
-"@vtex/api@6.40.0":
-  version "6.40.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.40.0.tgz#830c4aaaad75a1a8cf86ce898010e081a89053f8"
-  integrity sha512-VDdg9KVoNQ6KxH6cM0Tgh+VF7ELLrORqk5lRaie4akUZXW2tqECFLZAvRi9UE29CLstqCLBGQjqxbuT1aj/mgQ==
+"@vtex/api@6.42.1":
+  version "6.42.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.42.1.tgz#b0030afa16750f995bf8296bdc8b22ce2fa5907b"
+  integrity sha512-b9U+G1ZuZ6MOsbiLn+/FEW/XnTIGnsKam1YxUf7OHJhPY+ebupkxIhFeAWub/Mf8xELaNl+0EdrwUbuq4dNFxQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1489,6 +1489,7 @@
     semver "^5.5.1"
     stats-lite vtex/node-stats-lite#dist
     tar-fs "^2.0.0"
+    tokenbucket "^0.3.2"
     uuid "^3.3.3"
     xss "^1.0.6"
 
@@ -1946,6 +1947,11 @@ bl@^4.0.3:
     buffer "^5.5.0"
     inherits "^2.0.4"
     readable-stream "^3.4.0"
+
+bluebird@2.9.24:
+  version "2.9.24"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.24.tgz#14a2e75f0548323dc35aa440d92007ca154e967c"
+  integrity sha1-FKLnXwVIMj3DWqRA2SAHyhVOlnw=
 
 bluebird@^3.5.4:
   version "3.7.2"
@@ -4876,6 +4882,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redis@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-0.12.1.tgz#64df76ad0fc8acebaebd2a0645e8a48fac49185e"
+  integrity sha1-ZN92rQ/IrOuuvSoGReikj6xJGF4=
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -5526,6 +5537,14 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+tokenbucket@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tokenbucket/-/tokenbucket-0.3.2.tgz#8172b2b58e3083acc8d914426fed15162a3a8e90"
+  integrity sha1-gXKytY4wg6zI2RRCb+0VFio6jpA=
+  dependencies:
+    bluebird "2.9.24"
+    redis "^0.12.1"
 
 tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.5.0:
   version "2.5.0"

--- a/react/ChangeLocation.tsx
+++ b/react/ChangeLocation.tsx
@@ -6,10 +6,10 @@ import {
   initialLocationState,
 } from './components/LocationContext'
 
-const ChangeLocation: FunctionComponent = () => {
+const ChangeLocation: FunctionComponent = (props: any) => {
   return (
     <LocationContextProvider {...initialLocationState}>
-      <ChangeLocationContainer />
+      <ChangeLocationContainer {...props}/>
     </LocationContextProvider>
   )
 }

--- a/react/components/AddressInput.tsx
+++ b/react/components/AddressInput.tsx
@@ -43,7 +43,7 @@ const AddressInput: FunctionComponent<any> = ({
     }
 
     if (name === 'postalCode') {
-      return 'w-100'
+      return 'w-100 pb5'
     }
 
     return 'pb5 w-100'

--- a/react/components/ChangeLocationContainer.tsx
+++ b/react/components/ChangeLocationContainer.tsx
@@ -13,7 +13,7 @@ import { useLocationState } from './LocationContext'
 const CSS_HANDLES = ['changeLocationContainer'] as const
 
 const ChangeLocation: StorefrontFunctionComponent<WrappedComponentProps & any> = (props) => {
-  const {intl, postalCode, autocomplete, autofill} = props
+  const {intl, postalCode, autocomplete, autofill, notRequired, hideFields} = props
   const { loading, data } = useQuery(address, { ssr: false })
   const { data: logisticsData } = useQuery(Logistics, { ssr: false })
   const { location } = useLocationState()
@@ -66,6 +66,8 @@ const ChangeLocation: StorefrontFunctionComponent<WrappedComponentProps & any> =
         intl={intl}
         postalCode={postalCode}
         autocomplete={autocomplete}
+        hideFields={hideFields}
+        notRequired={notRequired}
         autofill={autofill}
       />
     </AddressRules>

--- a/react/components/ChangeLocationContainer.tsx
+++ b/react/components/ChangeLocationContainer.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import React from 'react'
 import { useQuery } from 'react-apollo'
 import { injectIntl, WrappedComponentProps } from 'react-intl'
 import { AddressRules } from 'vtex.address-form'
@@ -12,7 +12,8 @@ import { useLocationState } from './LocationContext'
 
 const CSS_HANDLES = ['changeLocationContainer'] as const
 
-const ChangeLocation: FunctionComponent<WrappedComponentProps> = ({ intl }) => {
+const ChangeLocation: StorefrontFunctionComponent<WrappedComponentProps & any> = (props) => {
+  const {intl, postalCode, autocomplete, autofill} = props
   const { loading, data } = useQuery(address, { ssr: false })
   const { data: logisticsData } = useQuery(Logistics, { ssr: false })
   const { location } = useLocationState()
@@ -63,6 +64,9 @@ const ChangeLocation: FunctionComponent<WrappedComponentProps> = ({ intl }) => {
         shipsTo={logisticsData.logistics?.shipsTo || []}
         googleMapsKey={logisticsData.logistics?.googleMapsKey || ''}
         intl={intl}
+        postalCode={postalCode}
+        autocomplete={autocomplete}
+        autofill={autofill}
       />
     </AddressRules>
   )

--- a/react/components/LocationContext.tsx
+++ b/react/components/LocationContext.tsx
@@ -4,7 +4,7 @@ import { helpers } from 'vtex.address-form'
 const { addValidation } = helpers
 
 interface LocationContextProps {
-  location: AddressFormFields
+  location: AddressFormFields,
 }
 
 type ReducerActions = {

--- a/react/components/LocationForm.tsx
+++ b/react/components/LocationForm.tsx
@@ -244,6 +244,14 @@ const LocationForm: FunctionComponent<WrappedComponentProps &
       return { results: [] }
     }
   }
+  const notRequired = ['complement','receiverName','reference']
+  const customRules = rules
+        customRules.fields = customRules.fields.map((field: any) => {
+          return {
+            ...field,
+            required: notRequired.indexOf(field.label) !== -1 ? false : true
+          }
+        })
 
   const handleSuccess = async (position: Position) => {
     // call Google Maps API to get location details from returned coordinates
@@ -288,7 +296,9 @@ const LocationForm: FunctionComponent<WrappedComponentProps &
     }
 
     const fieldsWithValidation = addValidation(geolocatedAddress)
-    const validatedFields = validateAddress(fieldsWithValidation, rules)
+    const validatedFields = validateAddress(fieldsWithValidation, customRules)
+
+    console.log('validatedFields =>', validatedFields)
 
     locationDispatch({
       type: 'SET_LOCATION',
@@ -400,15 +410,8 @@ const LocationForm: FunctionComponent<WrappedComponentProps &
     clearTimeout(geoTimeout)
     const curAddress = location
     const combinedAddress = { ...curAddress, ...newAddress }
-    const notRequired = ['complement','receiverName']
-    const validatedAddress = validateAddress(combinedAddress, rules)
-    const customRules = rules
-          customRules.fields = customRules.fields.map((field: any) => {
-            return {
-              ...field,
-              required: notRequired.indexOf(field.label) !== -1 ? false : true
-            }
-          })
+    const validatedAddress = validateAddress(combinedAddress, customRules)
+    
     geoTimeout = setTimeout(() => {
       if (
         newAddress?.postalCode?.value &&
@@ -429,6 +432,7 @@ const LocationForm: FunctionComponent<WrappedComponentProps &
         })
       } else {
         getGeolocation(googleMapsKey, validatedAddress).then((res: any) => {
+          console.log('Validated address =>', validateAddress)
           if (res?.length && isMountedRef.current) {
             locationDispatch({
               type: 'SET_LOCATION',

--- a/react/helpers/getParsedAddress.tsx
+++ b/react/helpers/getParsedAddress.tsx
@@ -11,12 +11,9 @@ const getCountryISO3 = require('country-iso-2-to-3')
  * @param {Object} place The place object returned from Google Maps API
  * @returns {Object} The reduced address data with only necessary fields/information
  */
-export const getParsedAddress = (place: {
-  address_components: any[]
-  geometry: any
-}) => {
+export const getParsedAddress = (place: any, autofill: any = null) => {
   const parsedAddressComponents = place.address_components.reduce(
-    (accumulator, address) => {
+    (accumulator: any, address:any) => {
       const parsedItem = address.types.reduce(
         (typeAccumulator: any, type: any) => ({
           ...typeAccumulator,
@@ -43,7 +40,7 @@ export const getParsedAddress = (place: {
       }${parsedAddressComponents.route}`
     : ''
 
-  const address = {
+  const fullAddress: any = {
     addressType: 'residential',
     city:
       parsedAddressComponents.locality ||
@@ -61,5 +58,22 @@ export const getParsedAddress = (place: {
     geoCoordinates: latitude && longitude ? [longitude, latitude] : null,
   }
 
-  return address
+  const basicAddress: any = {
+    addressType: fullAddress.addressType,
+    country: fullAddress.country, 
+    postalCode: fullAddress.postalCode,
+    geoCoordinates: fullAddress.geoCoordinates,
+    receiverName: fullAddress.receiverName,
+  }
+  const validKeys = ["city", "country", "neighborhood", "number", "postalCode", "state", "street"]
+  
+  if (autofill) {
+    autofill.forEach((field: string) => {
+      if (validKeys.indexOf(field) !== -1 && fullAddress[field]) {
+        basicAddress[field] = fullAddress[field]
+      }
+    })
+  }
+
+  return autofill ? basicAddress : fullAddress
 }

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -1,9 +1,5 @@
-import React, {
-  useEffect,
-  useState,
-  useCallback,
-  FunctionComponent,
-} from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useState, useCallback } from 'react'
 import { useQuery, useMutation } from 'react-apollo'
 import { injectIntl, WrappedComponentProps } from 'react-intl'
 import { ToastProvider } from 'vtex.styleguide'
@@ -20,10 +16,11 @@ const geolocationOptions = {
   maximumAge: 30000,
   timeout: 10000,
 }
-
-const AddressChallenge: FunctionComponent<WrappedComponentProps> = ({
-  children,
-}) => {
+let propAutofill: any = null
+const AddressChallenge: StorefrontFunctionComponent<WrappedComponentProps &
+  any> = (props: any) => {
+  const { autofill, children } = props
+  propAutofill = autofill
   const [updateAddress] = useMutation(UpdateOrderFormShipping)
   const { loading, data, refetch } = useQuery(Address, { ssr: false })
   const { data: logisticsData } = useQuery(Logistics, { ssr: false })
@@ -69,7 +66,10 @@ const AddressChallenge: FunctionComponent<WrappedComponentProps> = ({
       if (!parsedResponse.results.length) return
 
       // save geolocation to orderForm
-      const addressFields = getParsedAddress(parsedResponse.results[0])
+      const addressFields = getParsedAddress(
+        parsedResponse.results[0],
+        propAutofill
+      )
 
       addressFields.number = ''
       addressFields.street = ''
@@ -115,7 +115,10 @@ const AddressChallenge: FunctionComponent<WrappedComponentProps> = ({
         if (!parsedResponse.results.length) return
 
         // const { shipsTo = [] } = logisticsData?.logistics
-        const addressFields = getParsedAddress(parsedResponse.results[0])
+        const addressFields = getParsedAddress(
+          parsedResponse.results[0],
+          propAutofill
+        )
 
         addressFields.number = ''
         addressFields.street = ''
@@ -178,4 +181,18 @@ const AddressChallenge: FunctionComponent<WrappedComponentProps> = ({
   )
 }
 
+AddressChallenge.propTypes = {
+  props: PropTypes.shape({
+    children: PropTypes.any,
+    autofill: PropTypes.oneOf([
+      'city',
+      'country',
+      'neighborhood',
+      'number',
+      'postalCode',
+      'state',
+      'street',
+    ]),
+  }),
+}
 export default injectIntl(AddressChallenge)

--- a/react/typings/storefront.d.ts
+++ b/react/typings/storefront.d.ts
@@ -1,0 +1,13 @@
+import { FunctionComponent } from 'react'
+
+declare global {
+  interface StorefrontFunctionComponent<P = {}> extends FunctionComponent<P> {
+    getSchema?(props: P): object
+    schema?: object
+  }
+
+  interface StorefrontComponent<P = {}, S = {}> extends Component<P, S> {
+    getSchema?(props: P): object
+    schema: object
+  }
+}


### PR DESCRIPTION
### Fixed
- Selected address not showing up on the form
### Added
- Custom autofill, define which address fields will be filled with the property `autofill` on the `shopper-location` interface
- Autocomplete address based on the postalCode using Google's API, can be set for the `change-location` interface
- Adjust postalCode position at the form , can be set for the `change-location` interface
- `notRequired` and `hideFields` can be set on the `change-location` interface
- `changeLocationMapContainer` css handle

Back compatible theme [https://location--eriksbikeshop.myvtex.com/](https://location--eriksbikeshop.myvtex.com/)
![image](https://user-images.githubusercontent.com/24723/121082330-50e29780-c7b4-11eb-9634-153f28ce3bd1.png)


New implementation theme option 1 [https://location--carrefourbr.myvtex.com/](https://location--carrefourbr.myvtex.com/)
![image](https://user-images.githubusercontent.com/24723/121082373-62c43a80-c7b4-11eb-94cc-fef1a7f888f3.png)

option 2 [https://location2--carrefourbr.myvtex.com/](https://location2--carrefourbr.myvtex.com/)
![image](https://user-images.githubusercontent.com/24723/121083533-efbbc380-c7b5-11eb-825b-5547ecd258b8.png)

