### PR TITLE
[LOCATION-9] Run handleCountryChange function at first form render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Run handleCountryChange function at first form render.
+
 ## [1.4.6] - 2022-05-03
 
 ### Fixed

--- a/react/components/ChangeLocationContainer.tsx
+++ b/react/components/ChangeLocationContainer.tsx
@@ -39,7 +39,7 @@ const ChangeLocation: StorefrontFunctionComponent<WrappedComponentProps &
     )
   if ((!loading && !data) || !logisticsData) return null
 
-  const { address: queriedAddress } = data.orderForm?.shippingData || {}
+  const { address: queriedAddress } = data?.orderForm?.shippingData || {}
 
   const currentAddress = {
     addressQuery: '',
@@ -61,14 +61,14 @@ const ChangeLocation: StorefrontFunctionComponent<WrappedComponentProps &
     <AddressRules
       country={
         (location.country?.value ??
-          data.orderForm?.shippingData?.address?.country) ||
+          data?.orderForm?.shippingData?.address?.country) ||
         logisticsData.logistics?.shipsTo[0]
       }
       shouldUseIOFetching
       useGeolocation={false}
     >
       <LocationForm
-        orderForm={data.orderForm || null}
+        orderForm={data?.orderForm || null}
         currentAddress={currentAddress}
         shipsTo={logisticsData.logistics?.shipsTo || []}
         googleMapsKey={logisticsData.logistics?.googleMapsKey || ''}

--- a/react/components/LocationForm.tsx
+++ b/react/components/LocationForm.tsx
@@ -180,21 +180,18 @@ const LocationForm: FunctionComponent<WrappedComponentProps &
     )
   }
 
-  if (location?.country?.value === '') {
-    location.country.value = culture.country
-  }
-
   useEffect(() => {
     isMountedRef.current = true
     currentAddress.receiverName = currentAddress.receiverName || { value: ' ' }
-    const addressWithValidation = addValidation(currentAddress)
+    const country = (location?.country?.value ?? culture.country) || ''
 
     if (isMountedRef.current) {
-      locationDispatch({
-        type: 'SET_LOCATION',
-        args: {
-          address: addressWithValidation,
-        },
+      handleCountryChange({
+        country: { value: country },
+        city: { value: '' },
+        state: { value: '' },
+        neighborhood: { value: '' },
+        postalCode: { value: '' },
       })
     }
 

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -116,7 +116,7 @@ const AddressChallenge: StorefrontFunctionComponent<WrappedComponentProps &
         })
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [data?.orderForm, requestGoogleMapsApi, updateAddress]
+    [requestGoogleMapsApi, updateAddress]
   )
 
   const handleError = useCallback(() => {
@@ -175,7 +175,7 @@ const AddressChallenge: StorefrontFunctionComponent<WrappedComponentProps &
           })
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appSettingsData, data?.orderForm, requestGoogleMapsApi, updateAddress])
+  }, [appSettingsData, requestGoogleMapsApi, updateAddress])
 
   useEffect(() => {
     const handleLocationUpdated = () => refetch()

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -64,17 +64,20 @@ const AddressChallenge: StorefrontFunctionComponent<WrappedComponentProps &
     [logisticsData?.logistics?.googleMapsKey]
   )
 
-  const updateRegionID = async (address: AddressType) => {
-    const regionAddress = data.orderForm
+  const updateRegionID = useCallback(
+    async (address: AddressType) => {
+      const regionAddress = data?.orderForm
 
-    setRegionId({
-      variables: {
-        country: address.country,
-        postalCode: address.postalCode,
-        salesChannel: regionAddress.salesChannel,
-      },
-    })
-  }
+      setRegionId({
+        variables: {
+          country: address.country,
+          postalCode: address.postalCode,
+          salesChannel: regionAddress.salesChannel,
+        },
+      })
+    },
+    [data?.orderForm, setRegionId]
+  )
 
   const handleSuccess = useCallback(
     async (position: any) => {
@@ -115,8 +118,7 @@ const AddressChallenge: StorefrontFunctionComponent<WrappedComponentProps &
           window.dispatchEvent(event)
         })
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [requestGoogleMapsApi, updateAddress]
+    [requestGoogleMapsApi, updateAddress, updateRegionID]
   )
 
   const handleError = useCallback(() => {
@@ -174,8 +176,7 @@ const AddressChallenge: StorefrontFunctionComponent<WrappedComponentProps &
             window.dispatchEvent(event)
           })
       })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appSettingsData, requestGoogleMapsApi, updateAddress])
+  }, [appSettingsData, requestGoogleMapsApi, updateAddress, updateRegionID])
 
   useEffect(() => {
     const handleLocationUpdated = () => refetch()
@@ -208,7 +209,7 @@ const AddressChallenge: StorefrontFunctionComponent<WrappedComponentProps &
     <ToastProvider positioning="window">
       {children}
       <RedirectToast
-        orderForm={data.orderForm}
+        orderForm={data?.orderForm}
         appSettings={appSettingsData?.appSettings}
       />
     </ToastProvider>


### PR DESCRIPTION
[Related Ticket](https://vtex-dev.atlassian.net/browse/LOCATION-9)
[Workspace to test](https://arturovtex--emdesign.myvtex.com/gildan-fleece-crewneck-sweatshirt/p?__bindingAddress=www.emdesign.bg/)

Description:
Client is using the shopper-location app and is experiencing a problem on the Bulgaria store. See steps to replicate the problem:

go to a [PDP page](https://arturovtex--emdesign.myvtex.com/holna-garnitura-belle-310x250-sm-kafyavo-i-bejovo/p?__bindingAddress=www.emdesign.ro/), Bulgaria store:
Click on add location on the right pane.
The only available field was the country selector
The only way to display the other fields was to select 'Romain', then 'Bulgarian' again.
All the fields needed to be initially displayed.
Now i put the function in charge to render the fields at the first form render.